### PR TITLE
Generate Report Button/Basic Table UI

### DIFF
--- a/farmdata2_modules/fd2_tabs/fd2_barn_kit/fd2_barn_kit.module
+++ b/farmdata2_modules/fd2_tabs/fd2_barn_kit/fd2_barn_kit.module
@@ -65,6 +65,15 @@ function fd2_barn_kit_menu() {
     'weight' => -60,
   );
 
+  $items['farm/fd2-barn-kit/transplantingReport'] = array(
+    'title' => 'Transplanting Report',
+    'type' => MENU_LOCAL_TASK,
+    'page callback' => 'fd2_barn_kit_view',
+    'page arguments' => array('transplantingReport.html'),
+    'access arguments' => array('view fd2 barn kit'),
+    'weight' => -60,
+  );
+
   return $items;
 };
 

--- a/farmdata2_modules/fd2_tabs/fd2_barn_kit/transplantingReport.html
+++ b/farmdata2_modules/fd2_tabs/fd2_barn_kit/transplantingReport.html
@@ -1,20 +1,43 @@
-<body>
-<p>This is the new Transplanting Report Page</p>
-</body>
+<div id="transplantUI" v-cloak> 
 
-<label for="start">Start: </label>
-<input type="date" id="start" name="start-date"
-        value="2020-05-05" 
-        min="2014-01-01" max="2022-01-01">
+    <body>
+    <p>This is the new Transplanting Report Page</p>
+    </body>
 
-<label for="end">End: </label>
-<input type="date" id="end" name="end-date" 
-        value="2020-05-15" 
-        min="2020-05-05" max="2022-01-01">
+    <label for="start">Start: </label>
+    <input type="date" id="start" name="start-date"
+            value="2020-05-05" 
+            min="2014-01-01" max="2022-01-01">
+
+    <label for="end">End: </label>
+    <input type="date" id="end" name="end-date" 
+            value="2020-05-15" 
+            min="2020-05-05" max="2022-01-01">
+
 
 <br>
 <br>
 
-<button type="button">
-    Generate Report
-</button>
+    <button type="button">
+        Generate Report
+    </button>
+
+
+
+</div>
+
+<script>
+    new Vue({
+        el: '#transplantUI',
+        data: {
+            
+        },
+        methods: {
+
+        },
+        computed: {
+
+        }
+    })
+    Vue.config.devtools = true;
+</script>

--- a/farmdata2_modules/fd2_tabs/fd2_barn_kit/transplantingReport.html
+++ b/farmdata2_modules/fd2_tabs/fd2_barn_kit/transplantingReport.html
@@ -1,39 +1,45 @@
 <div id="transplantUI" v-cloak> 
 
-    <body>
-    <p>This is the new Transplanting Report Page</p>
-    </body>
+<!--fieldset groups together the heading, date input, and generate report button (styles are duplicated from the Seeding Report tab)-->
+    <fieldset class="panel panel-default center-block" style="width: 50%;">
+        <legend class="panel-heading" style="background-color: #d62a17; color: white;">Set Dates</legend>
+        <div style="display: flex;width: 100%; padding: 7px">
 
-    <label for="start">Start: </label>
-    <input type="date" id="start" name="start-date"
-            value="2020-05-05" 
-            min="2014-01-01" max="2022-01-01">
+        <!--This uses the dateRangeSelectionComponent defined in the FD2 Resources file - it defines the date input forms together.-->
+            <date-range-selection data-cy="date-range-selection"
+            class="center-block"  
+            default-start-date="2021-01-15" :default-end-date=dateRangeMaxDate @start-date-changed="startDateChange" @end-date-changed="endDateChange" 
+            >
+            </date-range-selection>
 
-    <label for="end">End: </label>
-    <input type="date" id="end" name="end-date" 
-            value="2020-05-15" 
-            min="2020-05-05" max="2022-01-01">
-
-
-<br>
-<br>
-
-    <button type="button">
-        Generate Report
-    </button>
-
-
-
-</div>
-
+            <!--Generate Report Button - uses the standard FD2 button style.-->
+            <button data-cy="generate-rpt-btn" class="btn center-block btn-primary">Generate Report</button>
+        </div>
+     </fieldset>
+</div> 
 <script>
     new Vue({
         el: '#transplantUI',
+        components: {
+            'date-range-selection': DateRangeSelectionComponent            
+        },
         data: {
-            
+            //variables for date range selection
+            startDate: null,
+            endDate: null,
+            dateRangeClicks: 0,
+            dateRangeMaxDate: dayjs().format("YYYY-MM-DD")
         },
         methods: {
-
+            //methods for date range selection
+            startDateChange(newDate) {
+                this.startDate = newDate
+                console.log(this.startDate)
+            },
+            endDateChange(newDate) {
+                this.endDate = newDate
+                console.log(this.startDate)
+            }           
         },
         computed: {
 

--- a/farmdata2_modules/fd2_tabs/fd2_barn_kit/transplantingReport.html
+++ b/farmdata2_modules/fd2_tabs/fd2_barn_kit/transplantingReport.html
@@ -1,0 +1,20 @@
+<body>
+<p>This is the new Transplanting Report Page</p>
+</body>
+
+<label for="start">Start: </label>
+<input type="date" id="start" name="start-date"
+        value="2020-05-05" 
+        min="2014-01-01" max="2022-01-01">
+
+<label for="end">End: </label>
+<input type="date" id="end" name="end-date" 
+        value="2020-05-15" 
+        min="2020-05-05" max="2022-01-01">
+
+<br>
+<br>
+
+<button type="button">
+    Generate Report
+</button>

--- a/farmdata2_modules/fd2_tabs/fd2_barn_kit/transplantingReport.html
+++ b/farmdata2_modules/fd2_tabs/fd2_barn_kit/transplantingReport.html
@@ -13,7 +13,57 @@
             </date-range-selection>
 
             <!--Generate Report Button - uses the standard FD2 button style.-->
-            <button data-cy="generate-rpt-btn" class="btn center-block btn-primary">Generate Report</button>
+            <button data-cy="generate-rpt-btn" class="btn center-block btn-primary" @click="reportButtonClicked">Generate Report</button>
+        </div>
+     </fieldset>
+
+     <fieldset>
+       <!-- <p v-if="!reportDisplay">No transplanting logs were found for the selected date range.</p>-->
+        <div v-if="reportDisplay">
+            <table border=1>
+                <tr>
+                    <!--<th>{{item}}</th>-->
+                    <th>Crop</th>
+                    <th>Field</th>
+                    <th>Tray Seeding Date</th>
+                    <th>Transpanting Date</th>
+                    <th>Days in Tray</th>
+                    <th>Bed Feet</th>
+                    <th>Rows/Bed</th>
+                    <th>Row Feet</th>
+                    <th>Trays</th>
+                    <th>Hours</th>
+                    <th>Comments</th>
+                    <th>User</th>
+                </tr>
+                <tr v-for="item in rows">
+                    <td>{{item.crop}}</td>
+                    <td>{{item.field}}</td>
+                    <td>{{item.tray_date}}</td>
+                    <td>{{item.transplant_date}}</td>
+                    <td>{{item.days}}</td>
+                    <td>{{item.bed_feet}}</td>
+                    <td>{{item.rows_bed}}</td>
+                    <td>{{item.row_feet}}</td>
+                    <td>{{item.trays}}</td>
+                    <td>{{item.hours}}</td>
+                    <td>{{item.comments}}</td>
+                    <td>{{item.user}}</td>
+                    <td><button type="button" @click="deleteItem">Delete</button></td>
+                </tr>
+                <!--
+                <tr v-for="(log, index) in log_list">
+                    <td>{{index+1}}</td>
+                    <td>{{log.date}}</td>
+                    <td>{{log.area}}</td>
+                    <td>{{log.crop}}</td>
+                    <td>{{log.yield}}</td>
+                    <td>{{log.units}}</td>
+                    <td><button type="button" @click="deleteItem">Delete</button></td>
+                </tr>
+                -->
+                
+            </table>
         </div>
      </fieldset>
 </div> 
@@ -28,18 +78,30 @@
             startDate: null,
             endDate: null,
             dateRangeClicks: 0,
-            dateRangeMaxDate: dayjs().format("YYYY-MM-DD")
+            dateRangeMaxDate: dayjs().format("YYYY-MM-DD"),
+            //display variables
+            reportDisplay: false,
+            //report table variables
+            columns : ["Crop", "Field", "Tray Seeding Date", "Transpanting Date", "Days in Tray", "Bed Feet", "Rows/Bed", "Row Feet", "Trays", "Hours", "Comments", "User"],
+            rows : []
         },
         methods: {
             //methods for date range selection
-            startDateChange(newDate) {
+            startDateChange: function(newDate) {
                 this.startDate = newDate
                 console.log(this.startDate)
             },
-            endDateChange(newDate) {
+            endDateChange: function(newDate) {
                 this.endDate = newDate
                 console.log(this.startDate)
-            }           
+            },
+            reportButtonClicked: function(){
+                this.reportDisplay = true
+                this.rows.push({crop: "BROCCOLI", field: "C", tray_date: "2022-03-08", transplant_date: "2022-04-05", days: '28', bed_feet: "400.0", rows_bed: "2", row_feet: "800.0", trays: "5", hours: ".02", comments: "", user: "nelsonw"})
+            },   
+            deleteItem: function(index){
+                this.rows.splice(index, 1)
+            }     
         },
         computed: {
 


### PR DESCRIPTION
__Pull Request Description__

This lines up with the "Implement submit button for date range" and "Implement basic report table UI" tasks on the Kanban board. It is not as concise to one task as it probably should be, but I have implemented the functionality of the 'Generate Report' Button, which now displays a very basic table UI with fake data when clicked. The next step will be to change the table to have the correct UI style (again we should use the 'Seeding Report' tab as the template) and retrieve the actual data using the FarmOS API.

---
__Licensing Certification__

FarmData2 is a [Free Cultural Work](https://freedomdefined.org/Definition) and all accepted contributions are licensed as described in the LICENSE.md file. This requires that the contributor holds the rights to do so. By submitting this pull request __I certify that I satisfy the terms of the [Developer Certificate of Origin](https://developercertificate.org/)__ for its contents.
