### PR TITLE
User column fixed

### DIFF
--- a/farmdata2_modules/fd2_tabs/fd2_barn_kit/transplantingReport.html
+++ b/farmdata2_modules/fd2_tabs/fd2_barn_kit/transplantingReport.html
@@ -75,7 +75,8 @@
             idToCropMap: new Map(),
             cropToIDMap: new Map(),
             userToIDMap: new Map(),
-            areaToIDMap: new Map()
+            areaToIDMap: new Map(),
+            idToUserMap: new Map()
         },
         methods: {
             //methods for date range selection
@@ -203,7 +204,7 @@
                             h.quantity[2].value,
                             h.quantity[3].value,
                             h.notes.value,
-                            h.uid.id
+                            $vm.idToUserMap.get(h.uid.id)
                         ]
                     }                    
                 })
@@ -270,6 +271,14 @@
                 })
                 .catch((err) => {
                     console.log("An error occurred in getting the areaToIDMap.")
+                    console.log(err)
+                })
+            getIDToUserMap()
+                .then((response) => {
+                    this.idToUserMap = new Map (response)
+                })
+                .catch((err) => {
+                    console.log("An error occurred in getting the idToUserMap.")
                     console.log(err)
                 })
         }


### PR DESCRIPTION
__Pull Request Description__

This PR fixes the "User" column of the report table. Previously, this column displayed the ID of the user in the IDToUserMap, not the user. This ID has now been mapped correctly to the user's name (e.g. worker2, admin). This also allows the current value in this column to display when the row is in edit mode.
---
__Licensing Certification__

FarmData2 is a [Free Cultural Work](https://freedomdefined.org/Definition) and all accepted contributions are licensed as described in the LICENSE.md file. This requires that the contributor holds the rights to do so. By submitting this pull request __I certify that I satisfy the terms of the [Developer Certificate of Origin](https://developercertificate.org/)__ for its contents.
