### PR TITLE
Fixed repeating error

### DIFF
--- a/farmdata2_modules/fd2_tabs/fd2_barn_kit/transplantingReport.html
+++ b/farmdata2_modules/fd2_tabs/fd2_barn_kit/transplantingReport.html
@@ -108,6 +108,13 @@
             },
             reportButtonClicked: function(){
                 this.reportDisplay = true
+                this.results = []
+
+                // totalNumHours = 0 
+                // totalNumTrays = 0
+                // totalRowBed = 0
+                // totalRowFeet = 0
+
                 //Converts selected date-times into unix date format
                 let timestampStart = dayjs(this.startDate).unix()
                 let timestampEnd= dayjs(this.endDate).unix()


### PR DESCRIPTION
__Pull Request Description__

This PR fixes several small errors in the Transplanting Report tab. Previously, when the user clicked "generate report", the report table would add the new rows on top of rows from a previous report request. Now, only the current rows requested are displayed. This also impacts the summary table - whereas previously the numbers summed across multiple requests, the table now only displays values from the current request.

---
__Licensing Certification__

FarmData2 is a [Free Cultural Work](https://freedomdefined.org/Definition) and all accepted contributions are licensed as described in the LICENSE.md file. This requires that the contributor holds the rights to do so. By submitting this pull request __I certify that I satisfy the terms of the [Developer Certificate of Origin](https://developercertificate.org/)__ for its contents.
